### PR TITLE
feat: Allow customization of the number of stack lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@poppinss/cliui": "^3.0.2",
         "jest-diff": "^27.5.1",
-        "youch": "^3.1.1",
+        "youch": "^3.2.0",
         "youch-terminal": "^2.1.3"
       },
       "devDependencies": {
@@ -2692,9 +2692,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11121,11 +11121,11 @@
       }
     },
     "node_modules/youch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.1.1.tgz",
-      "integrity": "sha512-H8DwI62kyzVAuumMiJTgOynPgKjuAWwns+LLjHhJKpnFP+n2yssC/XiDV0nuToIrm5WBsgmu8POmd7sFapFE8A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.2.0.tgz",
+      "integrity": "sha512-H+hTPaqFc1EDXHmp8sqOQe7pOvP3GlYovV+Dkg8sQ2RUy95p9gJeH2gJ64V4LYxh8wI8+4KqJjhbLt4DeUgzgQ==",
       "dependencies": {
-        "cookie": "^0.4.2",
+        "cookie": "^0.5.0",
         "mustache": "^4.2.0",
         "stacktracey": "^2.1.8"
       }
@@ -13239,9 +13239,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -19648,11 +19648,11 @@
       "dev": true
     },
     "youch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.1.1.tgz",
-      "integrity": "sha512-H8DwI62kyzVAuumMiJTgOynPgKjuAWwns+LLjHhJKpnFP+n2yssC/XiDV0nuToIrm5WBsgmu8POmd7sFapFE8A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.2.0.tgz",
+      "integrity": "sha512-H+hTPaqFc1EDXHmp8sqOQe7pOvP3GlYovV+Dkg8sQ2RUy95p9gJeH2gJ64V4LYxh8wI8+4KqJjhbLt4DeUgzgQ==",
       "requires": {
-        "cookie": "^0.4.2",
+        "cookie": "^0.5.0",
         "mustache": "^4.2.0",
         "stacktracey": "^2.1.8"
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   "dependencies": {
     "@poppinss/cliui": "^3.0.2",
     "jest-diff": "^27.5.1",
-    "youch": "^3.1.1",
+    "youch": "^3.2.0",
     "youch-terminal": "^2.1.3"
   },
   "publishConfig": {

--- a/src/Printer/index.ts
+++ b/src/Printer/index.ts
@@ -27,8 +27,14 @@ export class ErrorsPrinter {
    * Get Youch's JSON report of the given error
    */
   private async getYouchJson(error: any) {
-    const youch = new Youch(error, {})
-    youch.codeContext = this.stackLinesCount
+    const youch = new Youch(
+      error,
+      {},
+      {
+        postLines: this.stackLinesCount,
+        preLines: this.stackLinesCount,
+      }
+    )
     return youch.toJSON()
   }
 

--- a/src/Printer/index.ts
+++ b/src/Printer/index.ts
@@ -17,6 +17,21 @@ import { logger, icons } from '@poppinss/cliui'
  * Print test runner errors
  */
 export class ErrorsPrinter {
+  private stackLinesCount: number
+
+  constructor(options?: { stackLinesCount?: number }) {
+    this.stackLinesCount = options?.stackLinesCount || 2
+  }
+
+  /**
+   * Get Youch's JSON report of the given error
+   */
+  private async getYouchJson(error: any) {
+    const youch = new Youch(error, {})
+    youch.codeContext = this.stackLinesCount
+    return youch.toJSON()
+  }
+
   /**
    * Returns human readable message for error phase
    */
@@ -37,7 +52,7 @@ export class ErrorsPrinter {
    * Displays the error stack for a given error
    */
   private async displayErrorStack(error: any) {
-    const jsonResponse = await new Youch(error, {}).toJSON()
+    const jsonResponse = await this.getYouchJson(error)
     console.log(
       forTerminal(jsonResponse, {
         prefix: '  ',
@@ -72,7 +87,7 @@ export class ErrorsPrinter {
     /**
      * Display error stack with the main frame only
      */
-    const jsonResponse = await new Youch(error, {}).toJSON()
+    const jsonResponse = await this.getYouchJson(error)
     console.log(
       forTerminal(jsonResponse, {
         prefix: '  ',
@@ -103,7 +118,7 @@ export class ErrorsPrinter {
     /**
      * Display error stack with the main frame only
      */
-    const jsonResponse = await new Youch(error, {}).toJSON()
+    const jsonResponse = await this.getYouchJson(error)
     console.log(
       forTerminal(jsonResponse, {
         prefix: '  ',

--- a/src/Printer/index.ts
+++ b/src/Printer/index.ts
@@ -20,7 +20,7 @@ export class ErrorsPrinter {
   private stackLinesCount: number
 
   constructor(options?: { stackLinesCount?: number }) {
-    this.stackLinesCount = options?.stackLinesCount || 2
+    this.stackLinesCount = options?.stackLinesCount || 5
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

With the current spec reporter, on my 13" and my small terminal integrated in VScode, I find that it is not very readable with stack traces that are so big. So it's not a big deal but I thought it was cool to allow to parameterize it from the specReporter ( it's the next PR ).

I also thought about adding an option to totally disable stacktrace from specReporter but I'm not sure. It's useful to have them most of the time. What do you think about it ?

**This PR depends on this one: https://github.com/poppinss/youch/pull/43**

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)